### PR TITLE
Refactor/46 Filter에서 발생하는 예외 처리 Spring Security에서 처리하도록 변경

### DIFF
--- a/src/main/java/com/example/shopping/config/JwtFilter.java
+++ b/src/main/java/com/example/shopping/config/JwtFilter.java
@@ -90,8 +90,7 @@ public class JwtFilter extends OncePerRequestFilter {
             jwtLogAndSend(request, "Unsupported JWT token" , "지원되지 않는 JWT 토큰입니다.", e);
         }
         catch (Exception e) {
-            log.error("Internal server error", e);
-            throw new InsufficientAuthenticationException("Exception e");
+            jwtLogAndSend(request, "Internal Server error", "Exception e", e);
         }
     }
 

--- a/src/main/java/com/example/shopping/config/JwtFilter.java
+++ b/src/main/java/com/example/shopping/config/JwtFilter.java
@@ -81,13 +81,13 @@ public class JwtFilter extends OncePerRequestFilter {
             chain.doFilter(request, response);
         }
         catch (SecurityException | MalformedJwtException e) {
-            logAndSend(request, "Invalid JWT token", "유효하지 않는 JWT 서명입니다.", e);
+            jwtLogAndSend(request, "Invalid JWT token", "유효하지 않는 JWT 서명입니다.", e);
         }
         catch (ExpiredJwtException e) {
-            logAndSend(request, "Expired JWT token", "만료된 JWT 토큰입니다.", e);
+            jwtLogAndSend(request, "Expired JWT token", "만료된 JWT 토큰입니다.", e);
         }
         catch (UnsupportedJwtException e) {
-            logAndSend(request, "Unsupported JWT token" , "지원되지 않는 JWT 토큰입니다.", e);
+            jwtLogAndSend(request, "Unsupported JWT token" , "지원되지 않는 JWT 토큰입니다.", e);
         }
         catch (Exception e) {
             log.error("Internal server error", e);
@@ -95,7 +95,7 @@ public class JwtFilter extends OncePerRequestFilter {
         }
     }
 
-    private void logAndSend(HttpServletRequest request, String logMessage, String message, Exception e){
+    private void jwtLogAndSend(HttpServletRequest request, String logMessage, String message, Exception e){
         log.error("{} : {}", logMessage, e.getMessage());
         request.setAttribute("exceptionMessage", message);
         throw new BadCredentialsException(message);

--- a/src/main/java/com/example/shopping/config/SecurityConfig.java
+++ b/src/main/java/com/example/shopping/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.shopping.config;
 
+import com.example.shopping.domain.common.exception.CustomAccessDeniedHandler;
+import com.example.shopping.domain.common.exception.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -9,6 +11,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -20,6 +23,9 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final RedisTemplate<String, String> redisTemplate;
 
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception{
         httpSecurity.csrf(AbstractHttpConfigurer::disable)
@@ -28,7 +34,12 @@ public class SecurityConfig {
                         .requestMatchers("/auth/login", "/auth/register", "/auth/refresh").permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtFilter(redisTemplate, jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtFilter(redisTemplate, jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(configurer ->
+                        configurer
+                                .authenticationEntryPoint(authenticationEntryPoint)
+                                .accessDeniedHandler(accessDeniedHandler)
+                );
 
         return httpSecurity.build();
 

--- a/src/main/java/com/example/shopping/config/SecurityConfig.java
+++ b/src/main/java/com/example/shopping/config/SecurityConfig.java
@@ -44,5 +44,4 @@ public class SecurityConfig {
         return httpSecurity.build();
 
     }
-
 }

--- a/src/main/java/com/example/shopping/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/shopping/domain/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import com.example.shopping.domain.common.dto.AuthUser;
 import com.example.shopping.domain.common.dto.ResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -29,9 +30,8 @@ public class AuthController {
 
         SignupResponseDto responseData = authService.signup(request);
         ResponseDto<SignupResponseDto> response = new ResponseDto<>("회원가입이 완료되었습니다", responseData);
-        URI uri = URI.create("/users/" + responseData.getId());
 
-        return ResponseEntity.created(uri).body(response);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
     @PostMapping("/withdraw")

--- a/src/main/java/com/example/shopping/domain/common/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/shopping/domain/common/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,43 @@
+package com.example.shopping.domain.common.exception;
+
+import com.example.shopping.domain.common.dto.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        ExceptionCode status = ExceptionCode.FORBIDDEN;
+
+        String customMessage = request.getAttribute("exceptionMessage").toString();
+
+        String message = customMessage == null ? status.getMessage() : customMessage;
+
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(message, status);
+        String responseBody = objectMapper.writeValueAsString(errorResponseDto);
+
+        String uri = request.getAttribute("URI").toString();
+
+        log.error("FORBIDDEN: AccessDenied - Uri : {}", uri);
+
+        response.setStatus(status.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/com/example/shopping/domain/common/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/shopping/domain/common/exception/CustomAccessDeniedHandler.java
@@ -24,9 +24,10 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
         ExceptionCode status = ExceptionCode.FORBIDDEN;
 
-        String customMessage = request.getAttribute("exceptionMessage").toString();
-
-        String message = customMessage == null ? status.getMessage() : customMessage;
+        String message = status.getMessage();
+        if(request.getAttribute("exceptionMessage") != null){
+            message = request.getAttribute("exceptionMessage").toString();
+        }
 
         ErrorResponseDto errorResponseDto = new ErrorResponseDto(message, status);
         String responseBody = objectMapper.writeValueAsString(errorResponseDto);

--- a/src/main/java/com/example/shopping/domain/common/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/shopping/domain/common/exception/CustomAuthenticationEntryPoint.java
@@ -24,9 +24,10 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         ExceptionCode status = ExceptionCode.UNAUTHORIZED_REQUEST;
 
-        String customMessage = request.getAttribute("exceptionMessage").toString();
-
-        String message = customMessage == null ? status.getMessage() : customMessage;
+        String message = status.getMessage();
+        if(request.getAttribute("exceptionMessage") != null){
+            message = request.getAttribute("exceptionMessage").toString();
+        }
 
         ErrorResponseDto errorResponseDto = new ErrorResponseDto(message, status);
         String responseBody = objectMapper.writeValueAsString(errorResponseDto);

--- a/src/main/java/com/example/shopping/domain/common/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/shopping/domain/common/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,43 @@
+package com.example.shopping.domain.common.exception;
+
+import com.example.shopping.domain.common.dto.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        ExceptionCode status = ExceptionCode.UNAUTHORIZED_REQUEST;
+
+        String customMessage = request.getAttribute("exceptionMessage").toString();
+
+        String message = customMessage == null ? status.getMessage() : customMessage;
+
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(message, status);
+        String responseBody = objectMapper.writeValueAsString(errorResponseDto);
+
+        String uri = request.getAttribute("URI").toString();
+
+        log.error("UNAUTHORIZED: Not Authenticated Request - Uri : {}", uri);
+
+        response.setStatus(status.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/com/example/shopping/domain/common/exception/ExceptionCode.java
+++ b/src/main/java/com/example/shopping/domain/common/exception/ExceptionCode.java
@@ -7,27 +7,23 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionCode {
     // 400 BAD_REQUEST
     INVALID_USER_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 권한입니다"),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 상품 요청입니다."),
 
     // 401 UNAUTHORIZED
+    UNAUTHORIZED_REQUEST(HttpStatus.UNAUTHORIZED, "Spring Security 인증 통과 오류"),
     WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다"),
 
     // 403 FORBIDDEN
+    FORBIDDEN_REQUEST(HttpStatus.FORBIDDEN, "Spring Security 인과 통과 요류"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "해당 작업에 대한 권한이 없습니다."),
 
     // 404 NOT_FOUND
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다"),
     CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니에 등록된 상품을 찾을 수 없습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을수 없습니다."),
 
     // 409 CONFLICT
     ALREADY_EXISTS_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다"),
-
-    //400
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 상품 요청입니다."),
-
-    //404
-    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을수 없습니다."),
-
-    //409
     PRODUCT_OUT_OF_STOCK(HttpStatus.CONFLICT, "상품 재고가 부족합니다");
 
 

--- a/src/main/java/com/example/shopping/domain/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/shopping/domain/common/exception/GlobalExceptionHandler.java
@@ -2,9 +2,18 @@ package com.example.shopping.domain.common.exception;
 
 import com.example.shopping.domain.common.dto.ErrorResponseDto;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @RestControllerAdvice
@@ -16,5 +25,45 @@ public class GlobalExceptionHandler {
         ExceptionCode code = ex.getExceptionCode();
         ErrorResponseDto errorResponseDto = new ErrorResponseDto(ex.getCustomMessage(), code);
         return new ResponseEntity<>(errorResponseDto, code.getHttpStatus());
+    }
+
+    // Validation 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+
+        // response에 입력한 내용 순서대로 정리
+        List<String> sortlist = Arrays.stream(Objects.requireNonNull(ex.getBindingResult()
+                                .getTarget()).getClass()
+                        .getDeclaredFields())
+                .map(Field::getName)
+                .toList();
+
+        // 예외처리 목록 순서대로 정리
+        List<FieldError> sortErrors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .sorted(Comparator.comparingInt(e -> sortlist.indexOf(e.getField())))
+                .toList();
+
+        // 첫번째 예외처리 문구
+        String errorMessage = sortErrors.get(0).getDefaultMessage();
+        return getErrorResponse(status, errorMessage);
+    }
+
+    // 예상하지 못한 모든 일반 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDto> handleException(Exception ex) {
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        log.error("Exception: ", ex); // 전체 스택 트레이스 로그 출력
+        return getErrorResponse(status, ex.getMessage());
+    }
+
+    public ResponseEntity<ErrorResponseDto> getErrorResponse(HttpStatus status, String message) {
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+                message,
+                status.getReasonPhrase()
+        );
+        return new ResponseEntity<>(errorResponseDto, status);
     }
 }


### PR DESCRIPTION
## 상세 내용
기존 Filter에서 sendError를 통해 즉시 처리하던 방식 -> Spring Security에서 잡을 수 있는 excpetion으로 throw
Spring Security의 AuthenticationEntryPoint에서 받아서 처리하여
기존 ErorrResponseDto 형식으로 응답 받을 수 있도록 수정

AccessDeniedHandler는 인가를 처리하지만 해당 예외가 발생하지 않기 때문에 401 Unauthorized만 확인 가능할 것으로 보입니다
Forbidden 반응을 보셨다면 얘기해주세요
<br/>

## 주의 사항

<br/>

Close #46 